### PR TITLE
Make project work with newer versions of quick_xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-/target/
+target/
 **/*.rs.bk
 Cargo.lock
-/target/
-**/*.rs.bk
-
+modules/**
+*.bz2
+*.xml
 Session.vim

--- a/src/bin/build_definitions_db.rs
+++ b/src/bin/build_definitions_db.rs
@@ -1,18 +1,18 @@
 extern crate define3;
+extern crate getopts;
 extern crate regex;
 extern crate rusqlite;
-extern crate getopts;
 
-use define3::{Module, Template, Word};
-use define3::PageContent;
 use define3::parse_wikitext::parse_wikitext;
+use define3::PageContent;
+use define3::{Module, Template, Word};
 
 use getopts::Options;
 use regex::Regex;
 use rusqlite::{Connection, Transaction};
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
 use std::fs;
+use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
@@ -28,7 +28,10 @@ fn main() {
         "Japanese",
         "Korean",
         "Lojban",
-    ].iter().cloned().collect();
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
     // TODO: figure out POS list automatically
     let parts_of_speech: HashSet<&str> = [
@@ -51,14 +54,20 @@ fn main() {
         "Rafsi",
         "Romanization",
         "Verb",
-    ].iter().cloned().collect();
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
     let args: Vec<String> = std::env::args().collect();
     let mut opts = Options::new();
     opts.optflag("h", "help", "print this help text");
     let matches = opts.parse(&args[1..]).unwrap();
     if matches.opt_present("h") || matches.free.len() != 1 {
-        let brief = format!("Usage: {} PATH_TO_enwiktionary-YYYYMMDD-pages-meta-current.xml [options]", args[0]);
+        let brief = format!(
+            "Usage: {} PATH_TO_enwiktionary-YYYYMMDD-pages-meta-current.xml [options]",
+            args[0]
+        );
         print!("{}", opts.usage(&brief));
         return;
     }
@@ -88,7 +97,8 @@ fn main() {
              content        text not null
          )",
         [],
-    ).unwrap();
+    )
+    .unwrap();
 
     tx.execute("DROP TABLE IF EXISTS modules", []).unwrap();
     tx.execute(
@@ -97,7 +107,8 @@ fn main() {
              content        text not null
          )",
         [],
-    ).unwrap();
+    )
+    .unwrap();
 
     let re_noinclude = Regex::new(r"<noinclude>(?P<text>(?s:.)*?)</noinclude>").unwrap();
     let re_includeonly = Regex::new(r"<includeonly>(?P<text>(?s:.)*?)</includeonly>").unwrap();
@@ -123,14 +134,16 @@ fn main() {
             tx.execute(
                 "insert into templates (name, content) values (?1, ?2)",
                 &[&title, &content.as_str()],
-            ).unwrap();
+            )
+            .unwrap();
             templates.insert(title.to_owned(), content);
         } else if page.title.starts_with("Module:") {
             let title = &page.title[7..];
             tx.execute(
                 "insert into modules (name, content) values (?1, ?2)",
                 [&title, &page.content.as_str()],
-            ).unwrap();
+            )
+            .unwrap();
 
             println!("Saved module: {}", page.title);
             let path = format!("modules/{}.lua", page.title);
@@ -153,7 +166,8 @@ fn main() {
              definition     text not null
          )",
         [],
-    ).unwrap();
+    )
+    .unwrap();
 
     define3::parse_xml::for_pages(&xml_path, |page| {
         let page_content = match page.title.split(':').next() {
@@ -196,7 +210,8 @@ fn main() {
                             &meaning.part_of_speech,
                             &defn.into_owned(),
                         ],
-                    ).unwrap();
+                    )
+                    .unwrap();
                 }
             }
             _ => (),
@@ -207,7 +222,8 @@ fn main() {
         "create index words_name_idx on words(name);
          create index words_language_idx on words(language);
          create index words_part_of_speech_idx on words(part_of_speech);",
-    ).unwrap();
+    )
+    .unwrap();
 
     tx.commit().unwrap();
 }

--- a/src/bin/build_definitions_db.rs
+++ b/src/bin/build_definitions_db.rs
@@ -133,7 +133,7 @@ fn main() {
             ).unwrap();
 
             println!("Saved module: {}", page.title);
-            let path = format!("/trove/data/enwikt/modules/{}.lua", page.title);
+            let path = format!("modules/{}.lua", page.title);
             let path = Path::new(&path);
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             let mut file = File::create(path).unwrap();

--- a/src/bin/define.rs
+++ b/src/bin/define.rs
@@ -51,6 +51,7 @@ fn get_defns_by_lang(
 // functions and often call out into Lua code.
 // https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions
 // https://www.mediawiki.org/wiki/Extension:Scribunto
+#[allow(dead_code)]
 fn expand_template(conn: &Connection, args: &[&str]) -> String {
     fn get_template_content(conn: &Connection, name: &str) -> String {
         let result = conn.query_row(
@@ -63,6 +64,7 @@ fn expand_template(conn: &Connection, args: &[&str]) -> String {
     }
     get_template_content(conn, args[0])
 }
+#[warn(dead_code)]
 
 // For now, we just hardcode a couple common templates.
 fn replace_template(_conn: &Connection, caps: &Captures) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod parse_xml;
 pub mod parse_wikitext;
+pub mod parse_xml;
 
 #[derive(Debug)]
 pub struct Meaning {

--- a/src/parse_wikitext.rs
+++ b/src/parse_wikitext.rs
@@ -96,31 +96,63 @@ pub fn parse_wikitext(
     let mut result: Vec<Meaning> = Vec::new();
     let mut context_stack: ContextStack = ContextStack::new();
 
-    let stack_apply = |context_stack: &mut ContextStack, wiki_context: &dyn Fn(String) -> WikiContext, line: &str, slice: &Option<&str>| {
-        slice.map_or_else(|| {
-            println!("Could not parse line: {}", line);
-        }, |slice| {
-            context_stack.apply(
-                wiki_context(slice.to_owned()),
-                languages,
-                parts_of_speech,
-            );
-        });
+    let stack_apply = |context_stack: &mut ContextStack,
+                       wiki_context: &dyn Fn(String) -> WikiContext,
+                       line: &str,
+                       slice: &Option<&str>| {
+        slice.map_or_else(
+            || {
+                println!("Could not parse line: {}", line);
+            },
+            |slice| {
+                context_stack.apply(wiki_context(slice.to_owned()), languages, parts_of_speech);
+            },
+        );
     };
 
     for line in text.lines() {
         if line.starts_with("======") && line.len() > 12 {
-            stack_apply(&mut context_stack, &|x| Heading6(x), line, &line.get(6..line.len()-6));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading6(x),
+                line,
+                &line.get(6..line.len() - 6),
+            );
         } else if line.starts_with("=====") && line.len() > 10 {
-            stack_apply(&mut context_stack, &|x| Heading5(x), line, &line.get(5..line.len()-5));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading5(x),
+                line,
+                &line.get(5..line.len() - 5),
+            );
         } else if line.starts_with("====") && line.len() > 8 {
-            stack_apply(&mut context_stack, &|x| Heading4(x), line, &line.get(4..line.len()-4));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading4(x),
+                line,
+                &line.get(4..line.len() - 4),
+            );
         } else if line.starts_with("===") && line.len() > 6 {
-            stack_apply(&mut context_stack, &|x| Heading3(x), line, &line.get(3..line.len()-3));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading3(x),
+                line,
+                &line.get(3..line.len() - 3),
+            );
         } else if line.starts_with("==") && line.len() > 4 {
-            stack_apply(&mut context_stack, &|x| Heading2(x), line, &line.get(2..line.len()-2));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading2(x),
+                line,
+                &line.get(2..line.len() - 2),
+            );
         } else if line.starts_with("=") && line.len() > 2 {
-            stack_apply(&mut context_stack, &|x| Heading1(x), line, &line.get(1..line.len()-1));
+            stack_apply(
+                &mut context_stack,
+                &|x| Heading1(x),
+                line,
+                &line.get(1..line.len() - 1),
+            );
         } else if line.starts_with("# ") {
             context_stack.language.as_ref().and_then(|language| {
                 context_stack.part_of_speech.as_ref().map(|part_of_speech| {

--- a/src/parse_xml.rs
+++ b/src/parse_xml.rs
@@ -1,10 +1,8 @@
 extern crate quick_xml;
+use parse_xml::quick_xml::{events::Event, Reader};
 
-use parse_xml::quick_xml::Reader;
-use parse_xml::quick_xml::events::Event;
-
-use std::path::Path;
 use std::io::BufRead;
+use std::path::Path;
 
 use Page;
 


### PR DESCRIPTION
This project is exactly what I was looking for. Thanks for writing it. :)

A few commits to get this building with newer quick_xml versions and some formatting.

- Ignore downloaded wiktionary files and modules subdirectory in .gitignore
- In build_definitions_db use a relative path for the modules directory
- Update xml parsing to work with newer versions of quick_xml
- Run cargo fmt on project
- Add pragma to disable warning about unused expand_template

Fixes: #1 